### PR TITLE
Applied design feedback to button

### DIFF
--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -7,6 +7,7 @@ import IconComponent from "./icons/icon"
 // Styles
 import { yellow, yellowDark, dark, darkest } from "../styles/colors"
 import * as textStyles from "../styles/textStyles"
+import mediaQueries from "../styles/mediaQueries"
 
 // Types
 interface IProps {
@@ -26,6 +27,7 @@ const Button: React.FC<IProps> = ({ children, icon, className }) => {
 export default Button
 
 const Icon = styled(IconComponent)`
+  margin-left: 8px;
   transition: transform 0.2s ease-in-out;
 `
 
@@ -33,7 +35,7 @@ const Container = styled.button`
   display: inline-flex;
   align-items: center;
   background: ${yellow};
-  padding: 12px 32px;
+  padding: 12px 24px;
   border-radius: 24px;
   border: none;
   cursor: pointer;
@@ -46,11 +48,19 @@ const Container = styled.button`
     color: ${darkest};
 
     > ${Icon} {
-      transform: translateX(16px);
+      transform: translateX(8px);
     }
   }
+
+  ${mediaQueries.from.breakpoint.XL`
+    padding: 12px 32px;
+
+    :hover {
+      > ${Icon} {
+        transform: translateX(16px);
+      }
+    }
+  `}
 `
 
-const Label = styled.span`
-  margin-right: 8px;
-`
+const Label = styled.span``


### PR DESCRIPTION
#### What does this PR do?

- [X] Made padding left and right 24px for screen sizes other than XL
- [X] Kept 32px of padding left and right for XL screen sizes
- [X] Moved margin between icon and button label from label to icon
- [X] Decreased `translateX` to 8px for screen sizes other than XL

#### How should this be tested?

Clone the repo, `yarn start` and go to `localhost:8000`. Buttons are in index page.

#### Any background context you want to provide?

Decreasing translateX value is discussed with Timo.

#### What are the relevant tickets?

#### Definition of Done (remove if not applicable):

- [X] Tested in supported browsers (Safari, Chrome, Firefox, IE11, Edge)
- [X] Tested on supported devices (Iphone, Ipad, Android phone, Android tablet)
- [X] No (offensive) mock data is used
(Only extra buttons in index page to test and review)