### PR TITLE
Applied design feedback to header

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react"
 import { Link } from "gatsby"
-import styled from "styled-components"
+import styled, { keyframes } from "styled-components"
 
 // Components
 import ContainerComponent from "./container"
@@ -64,7 +64,7 @@ const Header: React.FC<IProps> = ({
           <List>
             {usps.map(item => (
               <ListItem key={`usps-item-${item}`}>
-                <Icon icon="check" color={yellow} />
+                <Icon icon="check" width={24} color={yellow} />
                 {item}
               </ListItem>
             ))}
@@ -79,23 +79,6 @@ const Header: React.FC<IProps> = ({
             ))}
           </ButtonWrapper>
         )}
-        {/* {buttonLabel && (
-          <StyledLink to={`/${buttonUrl}`}>
-            <Button icon>{buttonLabel}</Button>
-          </StyledLink>
-        )}
-        {buttons && (
-          <div>
-            {buttons.map(button => (
-              <Link
-                to={button.buttonUrl}
-                key={`header-button-${button.buttonLabel}`}
-              >
-                <StyledButton icon>{button.buttonLabel}</StyledButton>
-              </Link>
-            ))}
-          </div>
-        )} */}
       </Wrapper>
     </Container>
   )
@@ -115,6 +98,16 @@ const Container = styled(ContainerComponent)`
   `}
 `
 
+const appear = keyframes`
+  30% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+`
+
 const ImageContainer = styled.div`
   ${aspectRatio(375, 248)}
   margin: 0;
@@ -129,6 +122,11 @@ const ImageContainer = styled.div`
   ${mediaQueries.from.breakpoint.L`
     ${aspectRatio(512, 512)}
     flex: 1 0 50%;
+    border-radius: 2px 0 0 2px;
+  `}
+
+  ${mediaQueries.from.px(1920)`
+    border-radius: 2px;
   `}
 `
 
@@ -138,10 +136,20 @@ const Image = styled.div<{ background?: string }>`
   background-image: url('${({ background }) => background}');
   background-size: cover;
   background-position: center center;
+
+  ${mediaQueries.from.breakpoint.L`
+    border-radius: 2px 0 0 2px;
+  `}
+
+  ${mediaQueries.from.px(1920)`
+    border-radius: 2px;
+  `}
 `
 
 const Lines = styled(IconComponent)`
   ${aspectRatioChild}
+  opacity: 0;
+  animation: ${appear} 1s linear forwards;
 `
 
 const Wrapper = styled.div`
@@ -175,9 +183,17 @@ const Title = styled.h1<{ type: string }>`
 `
 
 const List = styled.ul`
-  margin-bottom: 8px;
+  margin-bottom: 24px;
   padding: 0;
   list-style: none;
+
+  ${mediaQueries.from.breakpoint.M`
+    margin-bottom: 32px;
+  `}
+
+  ${mediaQueries.from.breakpoint.XL`
+    margin-bottom: 40px;
+  `}
 `
 
 const ListItem = styled.li`
@@ -188,6 +204,7 @@ const ListItem = styled.li`
 
 const Icon = styled(IconComponent)`
   margin-right: 12px;
+  flex: 0 0 ${({ width }) => width}px;
 `
 
 const Text = styled.p<{ type: string }>`
@@ -203,9 +220,18 @@ const Text = styled.p<{ type: string }>`
 
 const ButtonWrapper = styled.div`
   display: flex;
-  flex-flow: row nowrap;
+  flex-direction: column;
+
+  ${mediaQueries.from.px(375)`
+    flex-flow: row nowrap;
+  `}
 `
 
 const StyledButton = styled(Button)`
-  margin-right: 16px;
+  margin-bottom: 16px;
+
+  ${mediaQueries.from.px(375)`
+    margin-bottom: 0;
+    margin-right: 16px;
+  `}
 `

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -94,10 +94,6 @@ export default Navigation
 
 const ContentPusher = styled.div`
   ${mediaQueries.from.breakpoint.L`
-    margin-bottom: 144px;
-  `}
-
-  ${mediaQueries.from.breakpoint.XL`
     margin-bottom: 160px;
   `}
 `
@@ -105,7 +101,6 @@ const ContentPusher = styled.div`
 const Container = styled.div<IProps>`
   position: relative;
   background: ${white};
-  margin-bottom: 16px;
   padding: 0 16px;
   max-height: 160px;
   z-index: 9;


### PR DESCRIPTION
#### What does this PR do?

- [X] Set border radius on header image: 2;0;0;2 and above 1920 px screen sizes: 2px (2;2;2;2)
- [X] Updated margins between USP list and button according to the feedback
- [X] Added `flex: 0 0 width` to icons to preserve their size
- [X] Added custom media query for the buttons in Contact page to change position for the screens smaller than 375px
- [X] Added a simple transition to svg lines to delay their appearances so that the initial lines can be hidden
- [X] Adjusted the height of `ContentPusher` in navigation

#### How should this be tested?

Clone the repo, type `yarn start` then go to `localhost:8000` in the browser

#### Any background context you want to provide?

The keyframes applied to svg lines is not fixing svg bug but maybe used to work around it for now.

#### What are the relevant tickets?

#### Definition of Done (remove if not applicable):

- [X] Tested in supported browsers (Safari, Chrome, Firefox, IE11, Edge) (svg lines aren't properly displayed on IE)
- [X] Tested on supported devices (Iphone, Ipad, Android phone, Android tablet)
- [ ] No (offensive) mock data is used
Mock data is untouched.