### PR TITLE
Created componentWillMount hook to fix header lines bug

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react"
 import { Link } from "gatsby"
 import styled, { keyframes } from "styled-components"
+import useComponentWillMount from "../hooks/useComponentWillMount"
 
 // Components
 import ContainerComponent from "./container"
@@ -41,6 +42,8 @@ const Header: React.FC<IProps> = ({
       setIsWide(false)
     }
   }
+
+  useComponentWillMount(handleResize)
 
   useEffect(() => {
     setIsWide(window.innerWidth >= breakpoints.L)

--- a/src/hooks/useComponentWillMount.ts
+++ b/src/hooks/useComponentWillMount.ts
@@ -1,0 +1,11 @@
+import { useRef } from "react"
+
+const useComponentWillMount = (func: () => void) => {
+  const willMount = useRef(true)
+  if (typeof window !== "undefined" && willMount.current) {
+    func()
+  }
+  willMount.current = false
+}
+
+export default useComponentWillMount


### PR DESCRIPTION
#### What does this PR do?

- [X] Created an alternative for `componentWillMount` to set lines before render in order to prevent changing after render

#### How should this be tested?

Clone the repo, `yarn start`, `localhost:8000` then navigate between pages or reload the website

#### Any background context you want to provide?

Could be an alternative solution to fix changing lines.

#### What are the relevant tickets?

#### Definition of Done (remove if not applicable):

- [X] Tested in supported browsers (Safari, Chrome, Firefox, IE11, Edge) 
(Not working on initial landing on IE and Edge but it works when navigating between pages)
- [X] Tested on supported devices (Iphone, Ipad, Android phone, Android tablet)
- [X] No (offensive) mock data is used