### PR TITLE
Fixed alignment of the last TeamCard

### DIFF
--- a/src/components/teamCard.tsx
+++ b/src/components/teamCard.tsx
@@ -61,11 +61,17 @@ const Container = styled.div`
 
   ${mediaQueries.from.breakpoint.L`
     width: calc(33.3% - 21px);
+    margin-right: 32px;
+
+    :nth-child(3n) {
+      margin-right: 0;
+    }
   `}
 
   ${mediaQueries.from.breakpoint.XL`
     width: calc(33.3% - 16px);
     margin-bottom: 136px;
+    margin-right: 24px;
   `}
 `
 

--- a/src/components/teamMembers.tsx
+++ b/src/components/teamMembers.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 // Components
 import ContainerComponent from './container'
-import TeamCard from './teamCard'
+import Card from './teamCard'
 
 // Styles
 import mediaQueries from '../styles/mediaQueries'
@@ -37,14 +37,12 @@ const Container = styled(ContainerComponent)`
     justify-content: space-between;
   `}
 
+  ${mediaQueries.from.breakpoint.L`
+    justify-content: flex-start;
+  `}
+
   ${mediaQueries.from.breakpoint.XL`
     margin: 0 auto;
     padding: 0 20px;
   `}
-`
-
-const Card = styled(TeamCard)`
-  &:last-of-type {
-    align-self: flex-start;
-  }
 `


### PR DESCRIPTION
#### What does this PR do?

- [X] Change the way cards align

#### How should this be tested?

Check the cards on team page

#### Any background context you want to provide?

When there is for example 8 cards, last card was aligning right because of `justify-content: space-between;`

#### What are the relevant tickets?

[JIRA ticket](https://jungleminds.atlassian.net/jira/software/projects/AS/boards/183?selectedIssue=AS-65)

#### Definition of Done (remove if not applicable):

- [ ] Tested in supported browsers (Safari, Chrome, Firefox, IE11, Edge)
IE is broken at the moment
- [X] Tested on supported devices (Iphone, Ipad, Android phone, Android tablet)
- [X] No (offensive) mock data is used