### PR TITLE
Fixed form not submitting with first click

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@sendgrid/mail": "^7.2.2",
+    "axios": "^0.19.2",
     "formik": "^2.1.5",
     "gatsby": "^2.8.5",
     "gatsby-image": "^2.1.2",

--- a/src/components/contactForm.tsx
+++ b/src/components/contactForm.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import styled from 'styled-components'
+import axios from 'axios'
 import { Formik } from 'formik'
 import * as Yup from 'yup'
 
@@ -50,22 +51,16 @@ const ContactForm: React.FC<IProps> = ({ title, label, visible }) => {
     values: IContactForm,
     { setSubmitting }: any
   ) => {
-    setError(false)
-    await fetch('/.netlify/functions/mail', {
-      method: 'POST',
-      body: JSON.stringify(values),
-    })
-      .then(_ => setSuccess(true))
-      .catch(err => {
-        setError(true)
-        console.error(err)
-        if (err.response) {
-          console.error(err.response.body)
-        }
-      })
-      .finally(() => {
-        setSubmitting(false)
-      })
+    try {
+      setError(false)
+      await axios.post('/.netlify/functions/mail', JSON.stringify(values))
+      setSuccess(true)
+    } catch (error) {
+      setError(true)
+      console.error(error)
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return visible ? (
@@ -90,6 +85,15 @@ const ContactForm: React.FC<IProps> = ({ title, label, visible }) => {
             phone = (foo && foo.join(' ')) || phone
             return phone
           }
+
+          const submitButton = useMemo(
+            () => (
+              <Button type="submit" disabled={isSubmitting}>
+                {label}
+              </Button>
+            ),
+            [isSubmitting]
+          )
 
           return (
             <Form onSubmit={handleSubmit} noValidate>
@@ -164,9 +168,7 @@ const ContactForm: React.FC<IProps> = ({ title, label, visible }) => {
                   }
                   touched={!!touched.phone}
                 />
-                <Button type="submit" disabled={isSubmitting}>
-                  {label}
-                </Button>
+                {submitButton}
               </Wrapper>
             </Form>
           )


### PR DESCRIPTION
#### What does this PR do?

- [X] Changed submit button with a button with `useMemo`
- [X] Switched to `axios`

#### How should this be tested?

Focus on a field in form (click a field), while it is selected and focused, click submit button. It should submit the form (if there is no validation errors).

#### Any background context you want to provide?

When a field is focused, clicking the submit button triggers `onBlur` and it renders the button again. Once the button is rendered again, submit handler isn't called. Using `useMemo` will prevent the button re-render with `onBlur` and the form will proceed with submit handler.

About `axios`, `fetch` isn't supported in IE and for some reason `whatwg-fetch` polyfill was giving errors while building. Therefore I switched to `axios` which is working fine.

#### What are the relevant tickets?

[JIRA ticket](https://jungleminds.atlassian.net/jira/software/projects/AS/boards/183?selectedIssue=AS-54)

#### Definition of Done (remove if not applicable):

- [X] Tested in supported browsers (Safari, Chrome, Firefox, IE11, Edge)
- [X] Tested on supported devices (Iphone, Ipad, Android phone, Android tablet)
- [X] No (offensive) mock data is used