### PR TITLE
Changed linkResolver and pages to generate correct links

### DIFF
--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -36,7 +36,7 @@ const Banner: React.FC<IProps> = ({ heading, button, asset }) => {
         )}
       </Wrapper>
       {asset && (
-        <DownloadLink href={asset.url} target="_blank">
+        <DownloadLink href={asset.url}>
           <Icon icon="download" />
           <Label>{asset.label}</Label>
         </DownloadLink>

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -26,7 +26,6 @@ interface IProps {
   to?: string
   disabled?: boolean
   type?: 'button' | 'submit'
-  target?: string
   inverse?: boolean
   onClick?: () => void
 }
@@ -38,7 +37,6 @@ const Button: React.FC<IProps> = ({
   to,
   disabled,
   type,
-  target,
   inverse,
   onClick,
 }) => {
@@ -51,12 +49,15 @@ const Button: React.FC<IProps> = ({
 
   let result
 
-  if (
-    to &&
-    (to.includes('tel:') || to.includes('mailto:') || to.includes('http'))
-  ) {
+  if (to && to.includes('http')) {
     result = (
-      <Link className={className} href={to} target={target} inverse={inverse}>
+      <Link className={className} href={to} target="_blank" inverse={inverse}>
+        <Content />
+      </Link>
+    )
+  } else if (to && (to.includes('tel:') || to.includes('mailto:'))) {
+    result = (
+      <Link className={className} href={to} inverse={inverse}>
         <Content />
       </Link>
     )

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -51,14 +51,16 @@ export const pageQuery = graphql`
         header_buttonlabel
         header_buttonlink {
           url
-          slug
           type
+          slug
+          uid
         }
         header_secondary_buttonlabel
         header_secondary_buttonlink {
           url
           type
           slug
+          uid
         }
         body {
           ... on PrismicContactPageBodyCallToActionBanner {
@@ -72,6 +74,7 @@ export const pageQuery = graphql`
                 url
                 type
                 slug
+                uid
               }
             }
           }

--- a/src/pages/hypotheken.tsx
+++ b/src/pages/hypotheken.tsx
@@ -47,8 +47,10 @@ export const pageQuery = graphql`
         }
         header_buttonlabel
         header_buttonlink {
+          url
           type
           slug
+          uid
         }
         header_image {
           url
@@ -97,6 +99,7 @@ export const pageQuery = graphql`
                 url
                 type
                 slug
+                uid
               }
               how_we_work_button_label
             }
@@ -156,6 +159,7 @@ export const pageQuery = graphql`
                 url
                 type
                 slug
+                uid
               }
             }
             items {
@@ -167,6 +171,7 @@ export const pageQuery = graphql`
                 url
                 type
                 slug
+                uid
               }
               crosslink_item_image {
                 url

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -57,6 +57,7 @@ export const pageQuery = graphql`
           url
           type
           slug
+          uid
         }
         body {
           __typename
@@ -76,6 +77,7 @@ export const pageQuery = graphql`
                 url
                 type
                 slug
+                uid
               }
               service_buttonlabel {
                 text
@@ -103,6 +105,7 @@ export const pageQuery = graphql`
                 url
                 type
                 slug
+                uid
               }
               imagebanner_buttonlabel {
                 text

--- a/src/pages/verzekeren.tsx
+++ b/src/pages/verzekeren.tsx
@@ -47,8 +47,10 @@ export const pageQuery = graphql`
         }
         header_buttonlabel
         header_buttonlink {
+          url
           type
           slug
+          uid
         }
         header_image {
           url
@@ -73,12 +75,14 @@ export const pageQuery = graphql`
                 url
                 type
                 slug
+                uid
               }
               banner_download_label
               banner_download_link {
                 url
                 type
                 slug
+                uid
               }
             }
           }
@@ -141,6 +145,7 @@ export const pageQuery = graphql`
                 url
                 type
                 slug
+                uid
               }
             }
             items {
@@ -152,6 +157,7 @@ export const pageQuery = graphql`
                 url
                 type
                 slug
+                uid
               }
               crosslink_item_image {
                 url

--- a/src/schemas/assurance_page.json
+++ b/src/schemas/assurance_page.json
@@ -63,6 +63,7 @@
                 "type": "StructuredText",
                 "config": {
                   "multi": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Text"
                 }
               }
@@ -167,6 +168,7 @@
                 "type": "StructuredText",
                 "config": {
                   "multi": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Private description"
                 }
               },
@@ -195,6 +197,7 @@
                 "type": "StructuredText",
                 "config": {
                   "multi": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Business description"
                 }
               },
@@ -227,6 +230,7 @@
                 "type": "StructuredText",
                 "config": {
                   "multi": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Description"
                 }
               }

--- a/src/schemas/contact_page.json
+++ b/src/schemas/contact_page.json
@@ -17,6 +17,7 @@
       "type": "StructuredText",
       "config": {
         "multi": "strong, hyperlink",
+        "allowTargetBlank": true,
         "label": "Intro"
       }
     },

--- a/src/schemas/home_page.json
+++ b/src/schemas/home_page.json
@@ -17,6 +17,7 @@
       "type": "StructuredText",
       "config": {
         "multi": "strong, hyperlink",
+        "allowTargetBlank": true,
         "label": "Intro"
       }
     },
@@ -29,7 +30,8 @@
     "header_buttonlink": {
       "type": "Link",
       "config": {
-        "label": "Button link"
+        "label": "Button link",
+        "allowTargetBlank": true
       }
     },
     "header_image": {
@@ -86,6 +88,7 @@
                 "type": "StructuredText",
                 "config": {
                   "multi": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Description"
                 }
               },
@@ -115,6 +118,7 @@
                 "type": "StructuredText",
                 "config": {
                   "multi": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Text"
                 }
               }
@@ -186,6 +190,7 @@
                 "type": "StructuredText",
                 "config": {
                   "multi": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Text"
                 }
               },
@@ -221,7 +226,7 @@
               "review_text": {
                 "type": "StructuredText",
                 "config": {
-                  "multi": "strong, hyperlink",
+                  "multi": "strong",
                   "label": "Text"
                 }
               }

--- a/src/schemas/mortgage_page.json
+++ b/src/schemas/mortgage_page.json
@@ -65,6 +65,7 @@
                 "type": "StructuredText",
                 "config": {
                   "multi": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Text"
                 }
               }
@@ -123,6 +124,7 @@
                 "type": "StructuredText",
                 "config": {
                   "multi": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Text"
                 }
               }
@@ -166,6 +168,7 @@
                 "type": "StructuredText",
                 "config": {
                   "multi": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Content"
                 }
               }
@@ -189,6 +192,7 @@
                 "type": "StructuredText",
                 "config": {
                   "single": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Business description"
                 }
               },
@@ -203,6 +207,7 @@
                 "type": "StructuredText",
                 "config": {
                   "single": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Consumer description"
                 }
               },
@@ -264,6 +269,7 @@
                 "type": "StructuredText",
                 "config": {
                   "single": "strong, hyperlink",
+                  "allowTargetBlank": true,
                   "label": "Step content"
                 }
               }

--- a/src/schemas/team_page.json
+++ b/src/schemas/team_page.json
@@ -17,6 +17,7 @@
       "type": "StructuredText",
       "config": {
         "multi": "strong, hyperlink",
+        "allowTargetBlank": true,
         "label": "Intro"
       }
     },

--- a/src/util/data.ts
+++ b/src/util/data.ts
@@ -316,23 +316,16 @@ const handleLocationData = (data: any) => ({
 // Links
 // TODO: Improve link resolver - links are not handled correctly from the CMS data
 export const linkResolver = (link: any) => {
-  let result = '/'
-  if (link.type) {
+  const INFO_PAGE_PATH = `/informatie`
+  if (link.uid) {
     // Internal links
-    switch (link.type) {
-      case 'content_page':
-        result = `/${link.slug}`
-        break
-
-      case 'home_page':
-      default:
-        result = `/`
-        break
+    if (link.type !== 'content_page') {
+      return `/${link.uid}`
+    } else {
+      return `${INFO_PAGE_PATH}/${link.uid}`
     }
   } else {
     // External links
-    result = `${link.url}`
+    return `${link.url}`
   }
-
-  return result
 }


### PR DESCRIPTION
#### What does this PR do?

- [X] Added `uid` to fetch from Prismic for each link
- [X] Removed `target` property, any link that's external will be `target="_blank"` 
- [X] Changed `linkResolver` to generate correct links for content 

#### How should this be tested?
Click on any link it should bring you to the correct page. If it's external (any link starting with `http`, `tel` or `mailto`) it should open in a new tab.

#### Definition of Done (remove if not applicable):

- [X] Tested in supported browsers (Safari, Chrome, Firefox, IE11, Edge)
- [X] Tested on supported devices (Iphone, Ipad, Android phone, Android tablet)