### PR TITLE
Added target to Banner pdf link

### DIFF
--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -36,7 +36,7 @@ const Banner: React.FC<IProps> = ({ heading, button, asset }) => {
         )}
       </Wrapper>
       {asset && (
-        <DownloadLink href={asset.url}>
+        <DownloadLink href={asset.url} target="_blank">
           <Icon icon="download" />
           <Label>{asset.label}</Label>
         </DownloadLink>


### PR DESCRIPTION
#### What does this PR do?

- [X] Added `target="_blank"` to Banner pdf link

#### How should this be tested?

Banner component can be found on `Contact` and `Verzekeren` pages. The link for pdf should open in a new tab.

#### Any background context you want to provide?

#### What are the relevant tickets?

[JIRA ticket](https://jungleminds.atlassian.net/jira/software/projects/AS/boards/183?selectedIssue=AS-70)

#### Definition of Done (remove if not applicable):

- [X] Tested in supported browsers (Safari, Chrome, Firefox, IE11, Edge)
- [X] Tested on supported devices (Iphone, Ipad, Android phone, Android tablet)