### PR TITLE
Fix: hyperlink animation

### DIFF
--- a/src/styles/animations.ts
+++ b/src/styles/animations.ts
@@ -2,13 +2,13 @@ import { css, keyframes } from 'styled-components'
 
 // Styles
 import { dark, green } from './colors'
-import mediaQueries from './mediaQueries'
 
 // Types
 import { Iteration } from '../types/entities'
 
 const underline = css`
   position: relative;
+  display: inline-block;
 
   &::before,
   &::after {
@@ -22,12 +22,6 @@ const underline = css`
     background: ${dark};
     transition: transform 1.1s cubic-bezier(0.19, 1, 0.22, 1);
   }
-
-  ${mediaQueries.to.breakpoint.M`
-    &::before {
-      content: none;
-    }
-  `}
 
   &::before {
     transform: scaleX(0);


### PR DESCRIPTION

#### What does this PR do?

- [X] Added `display: inline-block` to hyperlink's css
- [X] Removed `content: none` for smaller screens

#### How should this be tested?

Check reviews in homepage, the last item (Grade block) has an inline hyperlink.

#### Any background context you want to provide?

Underline was disappearing between certain screen sizes.

#### What are the relevant tickets?

#### Definition of Done (remove if not applicable):

- [X] Tested in supported browsers (Safari, Chrome, Firefox, IE11, Edge)
- [X] Tested on supported devices (Iphone, Ipad, Android phone, Android tablet)
- [X] Connected to the CMS data
- [X] No (offensive) mock data is used